### PR TITLE
Remove deprecated @mui/styles package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.15.4",
         "@mui/material": "^5.15.4",
-        "@mui/styles": "^5.15.14",
         "@mui/x-data-grid": "^7.0.0",
         "@mui/x-date-pickers": "^6.19.4",
         "dayjs": "^1.11.9",

--- a/src/speedpicks/Entry.jsx
+++ b/src/speedpicks/Entry.jsx
@@ -13,13 +13,6 @@ import DataContext from '../context/DataContext'
 import {useTheme} from '@mui/material/styles'
 import useWindowSize from '../util/useWindowSize.jsx'
 import ErrorIcon from '@mui/icons-material/Error'
-import {makeStyles} from '@mui/styles'
-
-const useStyles = makeStyles({
-    alert : {
-        color: '#E15C07FF'
-    }
-})
 
 const Entry = ({entry, expanded, onExpand, bestTimes, entriesUpdate}) => {
 
@@ -110,9 +103,8 @@ const Entry = ({entry, expanded, onExpand, bestTimes, entriesUpdate}) => {
         ...divFlexStyle
     }
 
-    const classes = useStyles()
     const expandIcon = entry.status === 'rejected'
-        ? <ErrorIcon  className={classes.alert}/>
+        ? <ErrorIcon style={{color: '#E15C07FF'}}/>
         : <ExpandMoreIcon/>
 
     const timeString = entry.status === 'rejected'


### PR DESCRIPTION
Removes the `@mui/styles` package that is deprecated and giving a hard time when wanting to install anything new or do anything with npm really as its only supporting `react@^17.0.0` and we're using react 18.